### PR TITLE
Fix millet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-millet.toml
 mulligan

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "millet.server.diagnostics.moreInfoHint.enable": false
+}

--- a/millet.toml
+++ b/millet.toml
@@ -1,0 +1,12 @@
+version = 1
+[workspace]
+root = "src/top/sources.mlb"
+[workspace.path-vars]
+COMPAT = { value = "mlton" }
+[language]
+fixity-across-files = true
+[diagnostics]
+4014.severity = "ignore"
+4030.severity = "ignore"
+5029.severity = "ignore"
+5034.severity = "ignore"

--- a/src/context/basis.sml
+++ b/src/context/basis.sml
@@ -108,7 +108,7 @@ structure Basis :
                   acc andalso
                   (case List.find (fn {lab = lab', ...} => Symbol.eq (lab, lab')) fields2 of
                     NONE => false
-                  | SOME {value = value', ...} => poly_eq value value'
+                  | SOME {value = value', lab = _} => poly_eq value value'
                   )
                 )
                 true

--- a/src/context/value.sml
+++ b/src/context/value.sml
@@ -203,15 +203,12 @@ structure Value : VALUE =
             exps
       | Eparens exp => exp_is_value ctx exp
       | Eapp {left = Eident {opp, id}, right} =>
-          if Context.is_con ctx id (* THINK: or is exn? *) then
-            exp_is_value ctx right
-          else
-            false 
+          Context.is_con ctx id (* THINK: or is exn? *)
+          andalso exp_is_value ctx right
       | Einfix {left, id, right} =>
-          if Context.is_con ctx [id] (* THINK: or is exn? *) then
-            exp_is_value ctx left andalso exp_is_value ctx right
-          else
-            false
+           Context.is_con ctx [id] (* THINK: or is exn? *)
+           andalso exp_is_value ctx left
+           andalso exp_is_value ctx right
       | Etyped {exp, ...} => exp_is_value ctx exp 
       | ( Eseq _ (* THINK: eseq singleton? *)
         | Eapp _
@@ -321,7 +318,7 @@ structure Value : VALUE =
                 (fn ({lab, value}, acc) =>
                   case List.find (fn {lab = lab', ...} => Symbol.eq (lab, lab')) fields2 of
                     NONE => false
-                  | SOME {value = value', ...} =>
+                  | SOME {value = value', lab = _} =>
                       value_eq (value, value') andalso acc
                 )
                 true

--- a/src/debugger/debugger.sml
+++ b/src/debugger/debugger.sml
@@ -238,7 +238,7 @@ structure Debugger : DEBUGGER =
               exps
               |> eval_list (fn (left, right) =>
                   ( labs
-                  , left @ [Ehole] @ right
+                  , left @ Ehole :: right
                   )
                   |> ListPair.mapEq (fn (lab, exp) => {lab = lab, exp = exp})
                   |> Erecord
@@ -253,13 +253,13 @@ structure Debugger : DEBUGGER =
             end
         | Etuple exps =>
             eval_list
-              (fn (left, right) => Etuple (left @ [Ehole] @ right))
+              (fn (left, right) => Etuple (left @ Ehole :: right))
               exps
             |> Vtuple
             |> throw
         | Elist exps =>
             eval_list
-              (fn (left, right) => Elist (left @ [Ehole] @ right))
+              (fn (left, right) => Elist (left @ Ehole :: right))
               exps
             |> Vlist
             |> throw
@@ -575,11 +575,9 @@ structure Debugger : DEBUGGER =
               ( while
                   (case value of
                     Vconstr {id = [x], arg = NONE} =>
-                      if Symbol.eq (x, sym_true) then
-                        true
-                      else if Symbol.eq (x, sym_false) then
-                        false
-                      else
+                      Symbol.eq (x, sym_true)
+                      orelse not (Symbol.eq (x, sym_false))
+                      orelse
                         Printf.cprintf ctx (`"While condition given non-bool value "fv"") value
                         |> eval_err
                   | _ =>

--- a/src/directive_parser/lex/lexer.sml
+++ b/src/directive_parser/lex/lexer.sml
@@ -82,7 +82,7 @@ structure Arg =
 
     val keywords : DToken.t Table.table = 
       let
-        val table = Table.table 60
+        val table : DToken.t Table.table = Table.table 60
       
         val () =
           List.app

--- a/src/statics/statics.sml
+++ b/src/statics/statics.sml
@@ -2054,7 +2054,7 @@ structure Statics : STATICS =
                                   \ type schemes for equality in signature matching.")
                                 id
                               |> prog_err
-                          | SOME {tyscheme = tyscheme', ...} =>
+                          | SOME {tyscheme = tyscheme', id = _} =>
                               ( eq_tyschemes tyscheme tyscheme'
                               ; ()
                               )

--- a/src/top/top.sml
+++ b/src/top/top.sml
@@ -147,7 +147,7 @@ structure Top =
           , running = false
           , print_flag = true 
           , colored_output = not no_color 
-          , commands = []
+          , commands = [] : Directive.t list
           }
       in
         if doHelp orelse List.null args then

--- a/src/util/pervasive.sml
+++ b/src/util/pervasive.sml
@@ -56,7 +56,7 @@ fun push x r = r := x :: (!r)
 fun files_of_directory path =
   let 
     val stream = OS.FileSys.openDir path
-    val files = ref [] 
+    val files : string list ref = ref []
 
     fun aux () =
       case OS.FileSys.readDir stream of 


### PR DESCRIPTION
Commits a millet.toml and gets the repo to 0 millet warnings or errors.

Mostly type annotations and extra record labels (which is like a type annotation). Also some refactoring of bool expressions and avoidance of `[x] @ ys`.