### PR TITLE
Fix new Millet lints

### DIFF
--- a/millet.toml
+++ b/millet.toml
@@ -8,4 +8,5 @@ fixity-across-files = true
 [diagnostics]
 4014.severity = "ignore"
 4030.severity = "ignore"
+4035.severity = "ignore"
 5034.severity = "ignore"

--- a/src/context/basis.sml
+++ b/src/context/basis.sml
@@ -188,7 +188,7 @@ structure Basis :
         ( self_tyid
         , 1
         , [ ("::", forall_single (fn var => TVarrow (TVprod [var, listof var], listof var)))
-          , ("nil", forall_single (fn var => listof var))
+          , ("nil", forall_single listof)
           ]
         )
       end
@@ -319,9 +319,9 @@ structure Basis :
         , TVarrow (TVprod [int_ty, int_ty], int_ty)
         )
       , ( "div"
-        , (fn Vtuple [Vnumber (Int _), Vnumber (Int 0)] => 
+        , (fn Vtuple [Vnumber (Int _), Vnumber (Int 0)] =>
               raise Context.Raise ([sym div_name], div_exnid, NONE)
-          | Vtuple [Vnumber (Int i1), Vnumber (Int i2)] => Vnumber (Int (i1 div i2)) 
+          | Vtuple [Vnumber (Int i1), Vnumber (Int i2)] => Vnumber (Int (i1 div i2))
           | _ => eval_err "invalid args to div"
           )
         , true
@@ -356,7 +356,7 @@ structure Basis :
         , TVarrow (TVprod [int_ty, int_ty], bool_ty)
         )
       , ( "mod"
-        , (fn Vtuple [Vnumber (Int _), Vnumber (Int 0)] => 
+        , (fn Vtuple [Vnumber (Int _), Vnumber (Int 0)] =>
               raise Context.Raise ([sym div_name], div_exnid, NONE)
           | Vtuple [Vnumber (Int i1), Vnumber (Int i2)] => Vnumber (Int (i1 mod i2))
           | _ => eval_err "invalid args to div"
@@ -499,10 +499,10 @@ structure Basis :
               )
               (* TODO: equality types *)
               , ( "@"
-                , (fn Vtuple [Vlist l1, Vlist l2] => Vlist (l1 @ l2)  
+                , (fn Vtuple [Vlist l1, Vlist l2] => Vlist (l1 @ l2)
                   | _ => eval_err "invalid arg to `@`"
                   )
-                , true 
+                , true
                 , ( Vsign
                   , SH.guard_tyscheme
                     (1, fn [tyval] => TVarrow (TVprod [mk_list_ty tyval, mk_list_ty tyval], mk_list_ty tyval)
@@ -535,7 +535,7 @@ structure Basis :
             )
           , ( "throw"
             , (fn Vbasis {function, name, is_infix} =>
-                Vbasis { function = fn x => function x
+                Vbasis { function = function
                        , name = sym ("throw[" ^ Symbol.toValue name ^ "]")
                        , is_infix = is_infix
                        }
@@ -633,7 +633,7 @@ structure Basis :
       , settings =
           { break_assigns = ref SymSet.empty
           , substitute = ref true
-          , print_all = ref false 
+          , print_all = ref false
           , print_dec = ref true
           , print_depth = ref 1
           , pause_currying = ref false

--- a/src/context/context.sml
+++ b/src/context/context.sml
@@ -1051,7 +1051,7 @@ structure Context :
 
     fun synth_ty datatype_fn tyvar_fn ctx ty =
       let
-        val synth_ty = fn ctx => fn ty => synth_ty datatype_fn tyvar_fn ctx ty
+        val synth_ty = synth_ty datatype_fn tyvar_fn
 
         fun handle_type_synonym tyvals id =
           case get_type_synonym ctx id of

--- a/src/context/value.sml
+++ b/src/context/value.sml
@@ -73,7 +73,7 @@ fun set_modspecs (Sigval {valspecs, tyspecs, dtyspecs, exnspecs, modspecs = _}) 
 
 (* Search through a sigval to map a module by a particular longid a.b.c .
  *)
-fun map_sigval_module (sigval as Sigval {valspecs, tyspecs, dtyspecs, exnspecs, modspecs}) longid f =
+fun map_sigval_module (sigval as Sigval {modspecs, ...}) longid f =
   case longid of
     [] => f sigval
   | outer::rest =>
@@ -169,7 +169,7 @@ structure Value : VALUE =
           )
       | Vfn {matches, env, ...} => Efn (matches, SOME env)
       (* For basis values *)
-      | Vbasis {name, function, is_infix = _} => Eident {opp = false, id = [name]}
+      | Vbasis {name, function = _, is_infix = _} => Eident {opp = false, id = [name]}
 
     fun exp_is_value ctx exp =
       case exp of
@@ -259,19 +259,19 @@ structure Value : VALUE =
             )
             fields
           |> opt_all
-          |> Option.map (fn fields => Vrecord fields)
+          |> Option.map Vrecord
       | Elist exps =>
           List.map
             (exp_to_value ctx)
             exps
           |> opt_all
-          |> Option.map (fn fields => Vlist fields)
+          |> Option.map Vlist
       | Etuple exps =>
           List.map
             (exp_to_value ctx)
             exps
           |> opt_all
-          |> Option.map (fn fields => Vtuple fields)
+          |> Option.map Vtuple
 
       | Eparens exp => exp_to_value ctx exp
       | Eapp {left = Eident {id, ...}, right} =>
@@ -649,7 +649,7 @@ structure Value : VALUE =
         | SPinclude signat =>
             merge_sigvals sigval (evaluate_signat ctx signat)
         | SPinclude_ids ids =>
-            List.map (fn id => get_sig ctx id) ids
+            List.map (get_sig ctx) ids
             |> List.foldl
                  (fn (sigval, acc_sigval) =>
                    merge_sigvals acc_sigval sigval

--- a/src/debugger/debugger.sml
+++ b/src/debugger/debugger.sml
@@ -1055,7 +1055,7 @@ structure Debugger : DEBUGGER =
                   (Context.enter_scope ctx)
                   strdecs
                 |> Context.enter_scope
-                |> (fn ctx' => eval_strdec (CLOSURE ctx :: location) right_dec ctx')
+                |> (eval_strdec (CLOSURE ctx :: location) right_dec)
                 |> Context.exit_local
             | _ =>
                 eval_strdec
@@ -1063,7 +1063,7 @@ structure Debugger : DEBUGGER =
                   left_dec
                   (Context.enter_scope ctx)
                 |> Context.enter_scope
-                |> (fn ctx' => eval_strdec (CLOSURE ctx :: location) right_dec ctx')
+                |> (eval_strdec (CLOSURE ctx :: location) right_dec)
                 |> Context.exit_local
           )
       | DMhole => raise Fail "shouldn't eval dmhole"

--- a/src/pretty-print/PrettyPrintAst.sml
+++ b/src/pretty-print/PrettyPrintAst.sml
@@ -1673,7 +1673,7 @@ struct
           let
             val (topdec_doc, bound_ids) = p_topdec' ctx topdec
           in
-            ( case acc of 
+            ( case acc of
                 NONE => SOME (topdec_doc)
               | SOME acc => SOME (acc $$ topdec_doc)
             , Binding.remove_bound_ids ctx bound_ids
@@ -1683,7 +1683,7 @@ struct
         )
         (NONE, ctx, empty_set)
         ast
-      |> (fn (doc, _, boundids) => 
+      |> (fn (doc, _, boundids) =>
             case doc of
               NONE => (text_syntax "", boundids)
             | SOME doc => (doc, boundids))
@@ -2085,13 +2085,12 @@ struct
 
   fun show_longid longid = PD.toString true (p_longid' longid)
 
-  fun promote' f =
-    fn ctx => fn x => f ctx x
+  fun promote' f = f
 
   val op ftv = fn z => newFormat (fn _ => fn x => show_tyval (Context.norm_tyval (Basis.initial ()) x)) z
   val op fe = fn acc => newFormat (promote' show_exp) acc
   val op fv = fn acc => newFormat (promote' show_value) acc
   val op fp = fn acc => newFormat (promote' show_pat) acc
-  val op fl = fn acc => newFormat (fn _ => fn x => show_longid x) acc
+  val op fl = fn acc => newFormat (fn _ => show_longid) acc
 
 end

--- a/src/statics/statics.sml
+++ b/src/statics/statics.sml
@@ -180,7 +180,7 @@ fun get_fname_args_info synth_pat fname_args ctx =
       let
         val (bindings_list, pat_tys) =
           pats
-          |> List.map (fn pat => synth_pat ctx pat)
+          |> List.map (synth_pat ctx)
           |> ListPair.unzip
       in
         (List.concat bindings_list, pat_tys)
@@ -325,7 +325,7 @@ structure Statics : STATICS =
      *)
     fun quantify_tyval tyvar_fn ctx ty =
       let
-        val quantify_tyval = fn ctx => fn ty => quantify_tyval tyvar_fn ctx ty
+        val quantify_tyval = quantify_tyval tyvar_fn
       in
         case (Context.norm_tyval ctx ty) of
           TVtyvar sym =>
@@ -414,7 +414,7 @@ structure Statics : STATICS =
             val res =
               List.foldl
                 (fn ({lab, tyval}, acc) =>
-                  SymDict.insertMerge acc lab tyval (fn tyval' => unify ctx tyval tyval')
+                  SymDict.insertMerge acc lab tyval (unify ctx tyval)
                 )
                 SymDict.empty
                 (fields1 @ fields2)
@@ -1495,7 +1495,7 @@ structure Statics : STATICS =
                       (Context.enter_scope ctx)
                       decs
                     |> Context.enter_scope
-                    |> (fn ctx' => f (Location.CLOSURE ctx :: location) right_dec ctx')
+                    |> (f (Location.CLOSURE ctx :: location) right_dec)
                     |> Context.exit_local
                 | _ =>
                     f
@@ -1503,7 +1503,7 @@ structure Statics : STATICS =
                       left_dec
                       (Context.enter_scope ctx)
                     |> Context.enter_scope
-                    |> (fn ctx' => f (Location.CLOSURE ctx :: location) right_dec ctx')
+                    |> (f (Location.CLOSURE ctx :: location) right_dec)
                     |> Context.exit_local
               )
             )

--- a/src/util/printf.sml
+++ b/src/util/printf.sml
@@ -50,7 +50,7 @@ structure Printf : PRINTF =
 
     fun promote f =
       (* unused context parameter *)
-      fn _ => fn x => f x
+      fn _ => f
 
     structure TC = TerminalColors
 

--- a/src/util/test_framework.sml
+++ b/src/util/test_framework.sml
@@ -109,7 +109,7 @@ structure TestFramework : TESTFRAMEWORK =
     fun modify_test modifier test =
       case test of
         Test (s, test, _) => Test (s, test, SOME modifier)
-      | Suite (s, tests) => Suite (s, List.map (fn test => modify_test modifier test) tests)
+      | Suite (s, tests) => Suite (s, List.map (modify_test modifier) tests)
 
     fun get_test_name (ctx : context) = #test_name ctx
 
@@ -144,7 +144,7 @@ structure TestFramework : TESTFRAMEWORK =
               ; true
               )
               handle TestFail s =>
-                ( print (red "[FAIL]\n") 
+                ( print (red "[FAIL]\n")
                 ; print (border ^ "\n")
                 ; print (red "Failure: " ^ lightblue test_name ^ "\n\n")
                 ; print (s ^ "\n")
@@ -203,7 +203,7 @@ structure TestFramework : TESTFRAMEWORK =
             print (green "All tests passed.\n")
           else
             ( print <| spf (`""fs": "fs" test cases.\n") (red "FAILED") (Int.toString failed)
-            ; OS.Process.exit OS.Process.failure 
+            ; OS.Process.exit OS.Process.failure
             )
         )
       end


### PR DESCRIPTION
Fixed/ignored new lints:

- detecting `{}` instead of `()`/`unit`
- detecting `fn x => f x` instead of `f`

Also more whitespace fixes